### PR TITLE
Small tweaks

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -78,7 +78,7 @@ build_rswap_directory <- function(project_path, force = F, verbose = F){
 
   # legacy support for old met files:
   # copies over any files with a "numeric" file type. (best way i could think of)
-  not_numeric <- str_split(file_list, "[.]", simplify = T)[,2] %>%
+  not_numeric <- stringr::str_split(file_list, "[.]", simplify = T)[,2] %>%
     as.numeric() %>% is.na() %>% suppressWarnings()
   met_files <- file_list[which(not_numeric == FALSE)]
   met_status <- file.copy(from = met_files, to = temp_directory)
@@ -124,7 +124,7 @@ update_swap_paths <- function(project_path, swap_exe,
 
     # parse the various paths
     rswap_dir <- paste0(project_path, "/rswap/")
-    swap_exe_name <- swap_exe %>% str_split("/") %>% unlist() %>% tail(n=1)
+    swap_exe_name <- swap_exe %>% stringr::str_split("/") %>% unlist() %>% tail(n=1)
     path_without_swap <-  swap_exe %>% str_remove(swap_exe_name)
     swap_main_file_path <- rswap_dir %>% str_remove(path_without_swap)
 
@@ -143,7 +143,7 @@ update_swap_paths <- function(project_path, swap_exe,
       if (parameters$value[swinco_index] == 3) {
         infil_index <- (parameters$param == "INIFIL") %>% which()
         if ((infil_index %>% length()) > 0) {
-          val <-  parameters$value[infil_index] %>% str_remove_all("'")
+          val <-  parameters$value[infil_index] %>% stringr::str_remove_all("'")
           newval <- glue("'{swap_main_file_path}{val}' ! Changed by rswap v{version} @ {Sys.time()}")
           parameters = change_swap_parameter(parameters, "INIFIL", newval, verbose)
         }
@@ -390,7 +390,8 @@ load_swap_output <-  function(project_path, archived = F, verbose = F){
   result_output$DATETIME <- result_output$DATETIME %>% as.Date()
   colnames(result_output)[1] <- "DATE"
 
-  new_cols <- result_output %>% colnames() %>% str_replace("\\..", "_") %>% str_remove("\\.")
+  new_cols <- result_output %>% colnames() %>%
+    stringr::str_replace("\\..", "_") %>% stringr::str_remove("\\.")
   colnames(result_output) <- new_cols
 
   result_daily <- utils::read.table(
@@ -526,8 +527,8 @@ filter_swap_data <- function(data, variable = NULL, depth = NULL){
 #'
 get_swap_depths <- function(data, variable = NULL) {
 
-  splitted <- colnames(data) %>% str_remove("obs") %>%
-    str_split("_") %>% unlist() %>% toupper()
+  splitted <- colnames(data) %>% stringr::str_remove("obs") %>%
+    stringr::str_split("_") %>% unlist() %>% toupper()
 
   char_index <- splitted %>% as.numeric %>% is.na() %>% which() %>% suppressWarnings()
 
@@ -541,7 +542,7 @@ get_swap_depths <- function(data, variable = NULL) {
     var_cols <- vars %in% all_vars %>% which()
   }
 
-  depths <- colnames(data)[var_cols] %>% str_split("_") %>% unlist() %>% as.numeric() %>% suppressWarnings()
+  depths <- colnames(data)[var_cols] %>% stringr::str_split("_") %>% unlist() %>% as.numeric() %>% suppressWarnings()
   depths <- depths[which(depths %>% is.na() == FALSE)] # remove the NA values
   depths <- depths %>% unique()
 
@@ -591,7 +592,7 @@ match_swap_data <- function(project_path, variable, depth = NULL,
   }
 
   if(archived){
-    project_path<-project_path %>% str_remove("/rswap/")
+    project_path <- project_path %>% stringr::str_remove("/rswap/")
   }
 
   observed_data <- load_swap_observed(project_path = project_path, verbose = verbose, archived = archived)
@@ -767,7 +768,7 @@ rswap_init <- function(swap_exe){
   new_name <- old_name %>% str_replace("swap.swwp", "swap.swp")
   file.rename(old_name, new_name)
 
-  exe_name <-swap_exe %>% str_split("/") %>% unlist() %>% tail(1)
+  exe_name <-swap_exe %>% stringr::str_split("/") %>% unlist() %>% tail(1)
   wd <- swap_exe %>% str_remove(exe_name)
 
   example_path <- paste0(wd, "hupselbrook")

--- a/R/run.R
+++ b/R/run.R
@@ -45,10 +45,6 @@ run_swap <- function(project_path,
                      verbose = F,
                      timeout = Inf) {
 
-  # remove last backslash if accidentally passed
-  if (substr(project_path, nchar(project_path), nchar(project_path)) == "/") {
-    project_path <- substr(project_path, 0, nchar(project_path) - 1)
-  }
 
   # if more than one project is passed, then run them in parallel.
   if(length(project_path) > 1){
@@ -64,6 +60,11 @@ run_swap <- function(project_path,
       timeout = timeout
     )
     return(par_result)
+  }else{
+    # remove last backslash if accidentally passed
+    if (substr(project_path, nchar(project_path), nchar(project_path)) == "/") {
+      project_path <- substr(project_path, 0, nchar(project_path) - 1)
+    }
   }
 
   # IO timer start

--- a/R/run.R
+++ b/R/run.R
@@ -45,6 +45,11 @@ run_swap <- function(project_path,
                      verbose = F,
                      timeout = Inf) {
 
+  # remove last backslash if accidentally passed
+  if (substr(project_path, nchar(project_path), nchar(project_path)) == "/") {
+    project_path <- substr(project_path, 0, nchar(project_path) - 1)
+  }
+
   # if more than one project is passed, then run them in parallel.
   if(length(project_path) > 1){
     # TODO, better support for "swap.swp"

--- a/R/rw_parameters.R
+++ b/R/rw_parameters.R
@@ -31,14 +31,17 @@ clean_swap_file <- function(project_path, swap_file = "swap.swp") {
   if (comment_lines %>% length() > 0) {
     swp <- swp[-comment_lines]
   }
+
   # remove all the comment lines which start with "!"
   c_lines <- swp %>% stringr::str_trim()
+
   comment_lines2 = (substr(x = c_lines, 1, 1) == "!") %>% which()
   if (comment_lines2 %>% length() > 0) {
     swp <- swp[-comment_lines2]
   }
   # remove any empty lines
   c_lines <- swp %>% stringr::str_trim()
+
   empty_lines = (substr(x = c_lines, 1, 1) == "") %>% which()
   if (empty_lines %>% length() > 0) {
     swp <- swp[-empty_lines]
@@ -441,7 +444,7 @@ set_swap_output <-
     } else{
       if(verbose){
         cat("\u2795",
-            blue("adding", bold("SWCSV = 1"), "to parameter list"))
+            blue("adding", bold("SWCSV = 1"), "to parameter list\n"))
       }
       rbind(parameters,
             data.frame(
@@ -452,7 +455,6 @@ set_swap_output <-
     }
     # when more output is needed, I will need to add more and more, so this
     # should / will be updated to do as a loop, as it is done below:
-
 
     if(autoset_output){
 

--- a/R/rw_parameters.R
+++ b/R/rw_parameters.R
@@ -482,9 +482,8 @@ set_swap_output <-
       obs <- load_swap_observed(project_path, archived = F, verbose = verbose, force = force)
       variables <- get_swap_variables(swap_data = obs, verbose = verbose) %>% toupper()
       depths <- get_swap_depths(data = obs) %>% sort()
-      cat("\u2139",
-          blue("Following depths detected in SWAP output:"),
-          green(bold(underline(depths))), "\n")
+      if(verbose){cat("\u2139",blue("Following depths detected in SWAP output:"),
+          green(bold(underline(depths))), "\n")}
 
       # CREATING INLIST_CSV
       # TODO need to expand these... or figure out how to do this.

--- a/R/rw_parameters.R
+++ b/R/rw_parameters.R
@@ -419,25 +419,17 @@ set_swap_output <-
 
     }
 
-
     # add the critical output params if they are not present.
-    if("INLIST_CSV" %in% parameters$param == FALSE){
-      if(verbose){
-        cat("\u2795",
-            blue("adding", bold("INLIST_CSV = ''"), "to parameter list"))
+    # inlist CSV is only needed if we are autosetting output
+    if(autoset_output){
+      if("INLIST_CSV" %in% parameters$param == FALSE){
+        if(verbose){
+          cat("\u2795",
+              blue("adding", bold("INLIST_CSV = ''"), "to parameter list\n"))
+        }
+        add <- data.frame(param = "INLIST_CSV", value = "''", comment = glue("added by rswap on {Sys.time()}"))
+        parameters <- rbind(parameters, add)
       }
-      add <- data.frame(param = "INLIST_CSV", value = "", comment = glue("added by rswap on {Sys.time()}"))
-      parameters <- rbind(parameters, add)
-    }
-
-    # add the critical output params if they are not present.
-    if("INLIST_CSV_TZ" %in% parameters$param == FALSE){
-      if(verbose){
-        cat("\u2795",
-            blue("adding", bold("INLIST_CSV_TZ = ''"), "to parameter list"))
-      }
-      add <- data.frame(param = "INLIST_CSV_TZ ", value = "''", comment = glue("added by rswap on {Sys.time()}"))
-      parameters <- rbind(parameters, add)
     }
 
     # SWCSV needs to be present in the SWAP main file, such that the needed
@@ -456,21 +448,6 @@ set_swap_output <-
               param = "SWCSV",
               value = "1",
               comment = glue("added by rswap v{version} @ {Sys.time()}")
-            ))
-    }
-    # The exact same thing goes for SWCSV...
-    if ("SWCSV_TZ" %in% parameters$param) {
-      parameters = change_swap_parameter(parameters, "SWCSV_TZ", "1", verbose)
-    } else{
-      if(verbose){
-        cat("\u2795",
-            blue("adding", bold("SWCSV_TZ = 1"), "to parameter list"))
-      }
-      rbind(parameters,
-            data.frame(
-              param = "SWCSV_TZ",
-              value = "1",
-              comment = glue("added by rswap v{version} {Sys.time()}")
             ))
     }
     # when more output is needed, I will need to add more and more, so this

--- a/R/rw_parameters.R
+++ b/R/rw_parameters.R
@@ -22,6 +22,10 @@ clean_swap_file <- function(project_path, swap_file = "swap.swp") {
   # path and read
   path <- paste0(project_path, "/", swap_file)
   swp <- readLines(path)
+
+  # replace the degrees symbol with degC (causes error otherwise)
+  swp <- stringr::str_replace(swp, "\xbaC", "degC")
+
   # remove all the comment lines starting with *,
   comment_lines = (substr(x = swp, 1, 1) == "*") %>% which()
   if (comment_lines %>% length() > 0) {


### PR DESCRIPTION
- added some prefixing
- added some documentation to the `parallel` workflow
- parallel log file now includes project name
- parallel result dir now includes project name
- backslash is removed from `project_path` if it is passed in `run_swap()`, however,  not for parallel runs. 
- fixed an error with encoding celsius symbol (degree). Now `degC` is used instead.
- only auto-add  `INLIST_CSV_TZ` parameter if it is actually needed for the run (such as `AUTOSET_OUTPUT  = TRUE`)
- fixed some incorecct print to consoles